### PR TITLE
FEAT: add change user pw 2025-04-14

### DIFF
--- a/src/main/java/com/example/goodluck/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/goodluck/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import com.example.goodluck.exception.myboard.ForbiddenBoardAccessException;
 import com.example.goodluck.exception.myuser.UserLoginFaildException;
 import com.example.goodluck.exception.myuser.UserNotFoundException;
 import com.example.goodluck.exception.myuser.UserProfileImageUploadException;
+import com.example.goodluck.exception.myuser.UserPwNotMatchedException;
 import com.example.goodluck.exception.myuser.UserRegistFaildException;
 import com.example.goodluck.myuser.dto.RegistUserRequestDto;
 
@@ -85,6 +86,13 @@ public class GlobalExceptionHandler {
 
         return "redirect:/board/" + exception.getBoardInfo().getBoardNo();
     }
+
+    @ExceptionHandler(UserPwNotMatchedException.class)
+    public String handleUserPwNotMatchedException(UserPwNotMatchedException exception, Model model){
+        model.addAttribute("notice", exception.getMessage());
+        return "myuser/changePw_form";
+    }
+
     // dto 검증 시 발생 예외
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public String handleMethodArgumentNotValidException(
@@ -109,22 +117,21 @@ public class GlobalExceptionHandler {
         // String referer = request.getHeader("Referer");
         String requestUri = request.getRequestURI();
         if(requestUri != null && requestUri.contains("regist")){
-
-
             return "myuser/regist_form";
-        }else if(requestUri != null && requestUri.contains("login")){
-
-
+        }
+        else if(requestUri != null && requestUri.contains("login")){
             return "myuser/login";
-        }else if(requestUri != null && requestUri.contains("edit")){
-
-
+        }
+        else if(requestUri != null && requestUri.contains("edit")){
             return "myuser/mypage_form";
-        }else if(requestUri != null && requestUri.contains("write")){
-
-
+        }
+        else if(requestUri != null && requestUri.contains("write")){
             return "myboard/newboard_form";
         }
+        else if(requestUri != null && requestUri.contains("change-password")){
+            return "myuser/changePw_form";
+        }
+        
 
 
         return "error";

--- a/src/main/java/com/example/goodluck/exception/myuser/UserPwNotMatchedException.java
+++ b/src/main/java/com/example/goodluck/exception/myuser/UserPwNotMatchedException.java
@@ -1,0 +1,7 @@
+package com.example.goodluck.exception.myuser;
+
+public class UserPwNotMatchedException extends RuntimeException{
+    public UserPwNotMatchedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/goodluck/myuser/UserService.java
+++ b/src/main/java/com/example/goodluck/myuser/UserService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import com.example.goodluck.domain.MyUser;
 import com.example.goodluck.exception.myuser.UserLoginFaildException;
 import com.example.goodluck.exception.myuser.UserNotFoundException;
+import com.example.goodluck.exception.myuser.UserPwNotMatchedException;
 import com.example.goodluck.exception.myuser.UserRegistFaildException;
 
 
@@ -56,22 +57,22 @@ public class UserService {
                 .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자 정보입니다."))
                 .getUserNo());
     }
+
     // 비밀번호만 변경하는 경우
-    public MyUser updateUserPw(String userId, String newPw) throws RuntimeException{
-        
-        MyUser findUser = userRepository.selectById(userId)
-                                        .orElseThrow( 
-                                            () -> new IllegalStateException("회원 정보를 찾을 수 없습니다.")
-                                        );
-        if (findUser.getUserPw().equals(newPw)){
-            throw new IllegalStateException("이전 비밀번호는 사용할 수 없습니다."); 
-        }else if(newPw.isBlank()){
-            throw new IllegalStateException("새 비밀번호는 공백일 수 없습니다."); 
+    public MyUser updateUserPw(MyUser user, String oldPw, String newPw) throws RuntimeException{
+        // 이전 비밀번호가 사용자 비밀번호와 동일한지?
+        if( ! user.getUserPw().equals(oldPw)){
+            throw new UserPwNotMatchedException("기존 비밀번호 값이 동일하지 않습니다.");
         }
-        findUser.setUserPw(newPw);
+        // 이전 비밀번호와 새 비밀번호가 동일한지?
+        if( oldPw.equals(newPw)){
+            throw new UserPwNotMatchedException("새 비밀번호가 현재 비밀번호와 동일합니다.");
+        }
+
+        user.setUserPw(newPw);
     
-        return userRepository.updateUser(findUser)
-                                .orElseThrow(() -> new IllegalStateException("비밀번호 변경에 실패했습니다."));
+        return userRepository.updateUser(user)
+                             .orElseThrow(() -> new IllegalStateException("비밀번호 변경에 실패했습니다."));
     }
     
 

--- a/src/main/java/com/example/goodluck/myuser/dto/ChangePasswordDto.java
+++ b/src/main/java/com/example/goodluck/myuser/dto/ChangePasswordDto.java
@@ -1,0 +1,40 @@
+package com.example.goodluck.myuser.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.example.goodluck.common.MyDto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class ChangePasswordDto implements MyDto {
+    @NotBlank(message = "이전 비밀번호 값을 입력해주세요.")
+    private String oldPw;
+
+    @NotBlank(message = "새 비밀번호 값을 입력해주세요.")
+    private String newPw;
+    
+    @NotBlank(message = "새 비밀번호 확인 값을 입력해주세요.")
+    private String newPwCfm;
+
+    public boolean isNotConfirmPasswordValue(){
+        if(this.newPw.equals(newPwCfm)){
+            return true;
+        }
+        return false;
+    }
+    
+    @Override
+    public Map<String,String> toDomain() {
+        Map<String,String> result = new HashMap<>();
+
+        result.put("newPw", newPw);
+        result.put("oldPw", oldPw);
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/example/goodluck/myuser/dto/EditUserRequestDto.java
+++ b/src/main/java/com/example/goodluck/myuser/dto/EditUserRequestDto.java
@@ -19,7 +19,7 @@ public class EditUserRequestDto implements MyDto<MyUser>{
     private String userName;
     @NotBlank(message = "사용자 아이디는 필수값입니다.")
     private String userId;
-    @Size(min=5, max=16, message = "비밀번호는 6글자 이상, 16글자를 초과할 수 없습니다.")
+    @Size(min=5, max=16, message = "비밀번호는 6글자 미만, 16글자를 초과할 수 없습니다.")
     private String userPw;
     @Email(message = "이메일 형식이 아닙니다.")
     private String userEmail;

--- a/src/main/java/com/example/goodluck/myuser/dto/RegistUserRequestDto.java
+++ b/src/main/java/com/example/goodluck/myuser/dto/RegistUserRequestDto.java
@@ -13,7 +13,7 @@ public class RegistUserRequestDto implements MyDto<MyUser>{
     @NotBlank(message = "사용자 아이디는 필수값입니다.")
     private String userId;
     @NotBlank(message = "사용자 비밀번호는 필수값입니다.")
-    @Size(min=5, max=16, message = "비밀번호는 6글자 이상, 16글자를 초과할 수 없습니다.")
+    @Size(min=5, max=16, message = "비밀번호는 6글자 미만, 16글자를 초과할 수 없습니다.")
     private String userPw;
     @NotBlank(message = "사용자 이름은 필수값입니다.")
     private String userName;

--- a/src/main/resources/templates/myuser/changePw_form.html
+++ b/src/main/resources/templates/myuser/changePw_form.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Type" content="text/html" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Good Luck</title>
+        <!-- Bootstrap CSS -->
+        <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/minty/bootstrap.min.css" rel="stylesheet">
+    </head>
+
+    <body>
+        <!-- 공통 헤더 삽입 -->
+        <div th:replace="~{common/header :: header}"></div>
+
+        <div class="container d-flex justify-content-center align-items-center">
+            <!-- card start -->
+            <div class="card mt-4 mb-3"  style="width: 100%; max-width: 800px;">
+                <div class="card-body p-5">
+                    <h3 class="card-title mb-5 text-center">비밀번호 변경하기</h3>
+                    <form th:action="@{/mypage/change-password}" method="post" th:object="${changePasswordDto}" >
+                        <div>
+                            <label for="oldPw" class="form-label mt-4">기존 비밀번호</label>
+                            <input type="password" class="form-control" name="oldPw" id="oldPw" placeholder="기존 비밀번호를 입력해주세요">
+                        </div>
+                        <div>
+                            <label for="newPw" class="form-label mt-4">새 비밀번호</label>
+                            <input type="password" class="form-control" name="newPw" id="newPw" placeholder="새로운 비밀번호를 입력해주세요">
+                        </div>
+                        <div>
+                            <label for="newPwCfm" class="form-label mt-4">새 비밀번호 확인</label>
+                            <input type="password" class="form-control" name="newPwCfm" id="newPwCfm" placeholder="새로운 비밀번호를 한번 더 입력해주세요">
+                        </div>
+                        
+                        <th:block th:if="${notice != null}">
+                            <div class="d-grid gap-2 me-3 ms-3">
+                                <div class="alert alert-dismissible alert-secondary">
+                                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                                    <strong th:text="${notice}"></strong> 
+                                </div>
+                            </div>
+                        </th:block>
+
+                        <!-- 버튼 -->
+                        <div class="d-grid gap-2 mt-5">
+                            <button class="btn btn-lg btn-primary" type="submit">변경하기</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <!-- card start -->
+        </div>
+    </body>
+</html>

--- a/src/main/resources/templates/myuser/login.html
+++ b/src/main/resources/templates/myuser/login.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Good Luck</title>
     <!-- Bootstrap CSS -->
-    <!-- <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"> -->
     <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/minty/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
@@ -29,7 +28,6 @@
                 </div>
 
                 <!-- Checkbox -->
-                 
                 <div class="d-flex justify-content-start mt-4">
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault">

--- a/src/main/resources/templates/myuser/mypage_form.html
+++ b/src/main/resources/templates/myuser/mypage_form.html
@@ -52,7 +52,7 @@
                     <div class="input-group" id="userPw-group">
                         <input type="password" class="form-control" id="userPw" name="userPw" 
                             aria-describedby="userPwChange" readonly="" th:attr="value=${preValue.userPw}">
-                        <button class="btn btn-primary" type="button" id="userPwChange">비밀번호 변경</button>
+                        <button class="btn btn-primary" type="button" id="userPwChange" th:onclick="|location.href='@{/mypage/change-password}'|">비밀번호 변경</button>
                     </div>
                     <div>
                         <label for="userEmail" class="form-label mt-4">이메일</label>

--- a/src/test/java/com/example/goodluck/myuser/UserServiceTest.java
+++ b/src/test/java/com/example/goodluck/myuser/UserServiceTest.java
@@ -1,6 +1,8 @@
 package com.example.goodluck.myuser;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -20,6 +22,7 @@ import org.springframework.dao.DataAccessException;
 
 import com.example.goodluck.domain.MyUser;
 import com.example.goodluck.exception.myuser.UserLoginFaildException;
+import com.example.goodluck.exception.myuser.UserPwNotMatchedException;
 import com.example.goodluck.exception.myuser.UserRegistFaildException;
 
 @ExtendWith(MockitoExtension.class)
@@ -286,139 +289,74 @@ class UserServiceTest {
         }
     }
     
-    // *
-    // @Nested
-    // @DisplayName("회원 비밀번호 변경")
-    // class ChangeUserPw{
-    //     // given 공통
-    //     String newPw = "newPassword";
-    //     String oldPw = myUser.getUserPw();
 
-    //     @Nested
-    //     class SuccessCase{
-    //         @Test
-    //         @DisplayName("비밀 번호찾기로 비밀번호만 변경 성공")
-    //         void updateUserPw(){
-    //             // given
-    //             Mockito.when(mockUserRepository.selectById(myUser.getUserId())).thenReturn(Optional.of(myUser));
-    //             Mockito.when(mockUserRepository.updateUser(any(MyUser.class))).thenReturn(Optional.of(myUser));
-    //             // when
-    //             try{
-    //                 MyUser resultUser = userService.updateUserPw(myUser.getUserId(), newPw);
-    //                 // then
-    //                 Assertions.assertThat(myUser.getUserId()).isEqualTo(resultUser.getUserId());
-    //                 Assertions.assertThat(newPw).isEqualTo(resultUser.getUserPw());
-    //                 Assertions.assertThat(oldPw).isNotEqualTo(resultUser.getUserPw());
-    //             } catch(Exception e){
-    //                 // do nothing
-    //             }finally{
-    //                 // verify
-    //                 Mockito.verify(mockUserRepository).updateUser(myUser);
-    //                 Mockito.verify(mockUserRepository).selectById(myUser.getUserId());
-    //             }
-    //         }
-    //     }
-    //     @Nested
-    //     class FailCase{
-    //         @Test
-    //         @DisplayName("비밀번호 변경 - 회원 정보가 없는 경우")
-    //         void userNotFound(){
-    //             // given
-    //             Mockito.when(mockUserRepository.selectById(myUser.getUserId())).thenReturn(Optional.empty());
-    //             // Mockito.when(mockUserRepository.updateUser(user)).thenReturn(Optional.of(user));
-    //             // when
-    //             Throwable exception = Assertions.catchThrowable(() -> userService.updateUserPw(myUser.getUserId(), newPw));
-    //             // then
-    //             Assertions.assertThat(exception)
-    //                       .isInstanceOf(IllegalStateException.class)
-    //                       .hasMessageContaining("회원 정보를 찾을 수 없습니다.");
-    //             //verify
-    //             Mockito.verify(mockUserRepository).selectById(myUser.getUserId());
-    //             Mockito.verify(mockUserRepository, Mockito.never()).updateUser(Mockito.any());
-    //         }
-    //         @DisplayName("비밀번호 변경 - 이전 비밀번호와 동일한 경우")
-    //         @Test
-    //         void pwNotChanged(){
-    //             // given
-    //             Mockito.when(mockUserRepository.selectById(myUser.getUserId())).thenReturn(Optional.of(myUser));
-    //             // Mockito.when(mockUserRepository.updateUser(user)).thenReturn(Optional.of(user));
-    //             // when
-    //             Throwable exception = Assertions.catchThrowable(() -> userService.updateUserPw(myUser.getUserId(), myUser.getUserPw()));
-    //             // then
-    //             Assertions.assertThat(exception)
-    //                       .isInstanceOf(IllegalStateException.class)
-    //                       .hasMessageContaining("이전 비밀번호는 사용할 수 없습니다.");
-    //             // verfiy
-    //             Mockito.verify(mockUserRepository).selectById(myUser.getUserId());
-    //             Mockito.verify(mockUserRepository, Mockito.never()).updateUser(Mockito.any());
-    //         }
+    @Nested
+    @DisplayName("회원 비밀번호 변경 기능 테스트")
+    class ChangeUserPw{
 
-    //         @DisplayName("비밀번호 변경 - 비밀번호를 입력하지 않은 경우")
-    //         @Test
-    //         void blankPw(){
-    //             // given
-    //             Mockito.when(mockUserRepository.selectById(myUser.getUserId())).thenReturn(Optional.of(myUser));
-    //             // Mockito.when(mockUserRepository.updateUser(user)).thenReturn(Optional.of(user));
-    //             // when
-    //             Throwable exception = Assertions.catchThrowable(() -> userService.updateUserPw(myUser.getUserId(), ""));
-    //             // then
-    //             Assertions.assertThat(exception)
-    //                       .isInstanceOf(IllegalStateException.class)
-    //                       .hasMessageContaining("새 비밀번호는 공백일 수 없습니다.");
-    //             // verify
+        @Nested
+        class SuccessCase{
+            @Test
+            @DisplayName("비밀번호 변경에 성공한 경우")
+            void successUpdateUserPw(){
+                // given
+                MyUser testUser = MyUser.creatDummy(0L);
+                String newPassword = "new Password";
 
-    //         }
-    //         @DisplayName("비밀번호 변경 - DB 업데이트가 실패한 경우")
-    //         @Test
-    //         void dbUpdateException(){
-    //             // given
-    //             Mockito.when(mockUserRepository.selectById(myUser.getUserId())).thenReturn(Optional.of(myUser));
-    //             Mockito.when(mockUserRepository.updateUser(myUser)).thenThrow(new RuntimeException("런타임 에러"));
-    //             // when
-    //             Throwable exception = Assertions.catchThrowable(() -> userService.updateUserPw(myUser.getUserId(), newPw));
-    //             // then
-    //             Assertions.assertThat(exception)
-    //                       .isInstanceOf(RuntimeException.class)
-    //                       .hasMessage("런타임 에러");
+                BDDMockito.given(mockUserRepository.updateUser(any(MyUser.class))).willReturn(Optional.of(testUser));
+
+                // when
+                userService.updateUserPw(testUser, testUser.getUserPw(), newPassword);
+
+                // then
+                Assertions.assertThat(newPassword).isEqualTo(testUser.getUserPw());
+                Mockito.verify(mockUserRepository).updateUser(any(MyUser.class));
+
+            }
+        }
+
+        @Nested
+        class failCase{
+            @Test
+            @DisplayName("새 비밀번호가 조건을 통과 못 하는 경우")
+            void failDuplicatedUserPw(){
+                // given
+                MyUser testUser = MyUser.creatDummy(0L);
+                String newPassword = "testtest"; // 동일한 비밀번호
+                String oldPassword = "not same";
+
+                // when
+                Throwable exception1 = Assertions.catchThrowable(() -> userService.updateUserPw(testUser, testUser.getUserPw(), newPassword));
+                Throwable exception2 = Assertions.catchThrowable(() -> userService.updateUserPw(testUser, oldPassword, newPassword));
                 
-    //             Mockito.verify(mockUserRepository).selectById(myUser.getUserId());
-    //             Mockito.verify(mockUserRepository).updateUser(myUser);
-    //         }
-    //         @DisplayName("비밀번호 변경 - update 값이 null인 경우")
-    //         @Test
-    //         void userUpdateFail(){
-    //             // given
-    //             Mockito.when(mockUserRepository.selectById(any(String.class))).thenReturn(Optional.of(myUser));
-    //             Mockito.when(mockUserRepository.updateUser(any(MyUser.class))).thenReturn(Optional.empty());
-    //             // when
-    //             Throwable exception = Assertions.catchThrowable( ()-> userService.updateUserPw(myUser.getUserId(), newPw));
-    //             // then
-    //             Assertions.assertThat(exception)
-    //                       .isInstanceOf(IllegalStateException.class)
-    //                       .hasMessageContaining("비밀번호 변경에 실패했습니다.");
+                // then
+                Assertions.assertThat(exception1).isInstanceOf(UserPwNotMatchedException.class);
+                Assertions.assertThat(exception2).isInstanceOf(UserPwNotMatchedException.class);
+                
+                Assertions.assertThat(exception1).hasMessageContaining("동일합니다.");
+                Assertions.assertThat(exception2).hasMessageContaining("동일하지 않습니다.");
+                
 
-    //             Mockito.verify(mockUserRepository).selectById(myUser.getUserId());
-    //             Mockito.verify(mockUserRepository).updateUser(myUser);
-    //         }
-    //         // Mockito.verifyNoInteractions(mockUserRepository);
-    //     }
-    // }
+                Mockito.verify(mockUserRepository, never()).updateUser(any(MyUser.class));
+            }
 
-    // @Nested
-    // @DisplayName("회원 정보 삭제")
-    // class DeleteUser{
-    //     @Nested
-    //     @DisplayName("성공 케이스")
-    //     class SuccessCase{
-    //         @Test
-    //         @DisplayName("회원 정보 삭제 성공")
-    //         void deleteUser(){
+            @Test
+            @DisplayName("UserRepository에서 예외가 발생한 경우")
+            void failElseException(){
+                // given
+                MyUser testUser = MyUser.creatDummy(0L);
+                String newPassword = "new Password";
 
-    //         }
-    //     }
+                BDDMockito.given(mockUserRepository.updateUser(any(MyUser.class))).willReturn(Optional.of(testUser));
 
-    //     class FailCase{
-            
-    //     }
-    // }
+                // when
+                userService.updateUserPw(testUser, testUser.getUserPw(), newPassword);
+
+                // then
+                Assertions.assertThat(newPassword).isEqualTo(testUser.getUserPw());
+                Mockito.verify(mockUserRepository).updateUser(any(MyUser.class));
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## 연관된 이슈
> resolve: #10 

## 작업 내용
어떤 변경 사항이 있나요?
> 유저 비밀번호 변경 페이지 추가
* 사용자 흐름
1. 사용자가 "비밀번호 변경" 버튼을 클릭
2. Get Mapping "/mypage/change-password"
3. 이전 비밀번호 + 새 비밀번호 + 새 비밀번호 확인 입력
4. 새 비밀번호 규칙: 빈값 X+ 이전 비밀번호가 아니어야 함 성공 시: 리다이렉션 처리
실패 시: 메세지를 띄우거나 error 페이지 처리

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 커밋 메시지 컨벤션에 맞게 작성했나요? 